### PR TITLE
case sensitive: should change oRB_SLAM2_Android to ORB_SLAM2_Android

### DIFF
--- a/ORB_slam_test/settings.gradle
+++ b/ORB_slam_test/settings.gradle
@@ -1,2 +1,2 @@
 include ':openCVLibrary249'
-include ':oRB_SLAM2_Android'
+include ':ORB_SLAM2_Android'


### PR DESCRIPTION
in unix-like system, case sensitive should be avoided.
Signed-off-by: flydzp <flydzp@gmail.com>